### PR TITLE
BD-347: Resolve contact search page crashing

### DIFF
--- a/CRM/AdditionalSearchParams/Hook/BuildForm/SetBasicSearchUrlParamsAsDefault.php
+++ b/CRM/AdditionalSearchParams/Hook/BuildForm/SetBasicSearchUrlParamsAsDefault.php
@@ -40,12 +40,15 @@ class CRM_AdditionalSearchParams_Hook_BuildForm_SetBasicSearchUrlParamsAsDefault
    *   Form Class object.
    */
   private function setDefaultsForUrlParams($form) {
+    $defaults = $form->_defaultValues;
     foreach ($this->urlParameters as $paramName => $paramType) {
-      $paramValue = CRM_Utils_Request::retrieve($paramName, $paramType);
+      $paramValue = CRM_Utils_Request::retrieveValue($paramName, $paramType, NULL, FALSE, 'GET');
       if ($paramValue) {
-        $form->setDefaults([$paramName => $paramValue]);
+        $defaults[$paramName] = $paramValue;
       }
     }
+
+    $form->setDefaults($defaults);
   }
 
   /**


### PR DESCRIPTION
## Overview
This PR resolves the issue with the Contact page crashing after searching for contact by tags.

## Before
The contact search page crashes on searching for a contact by tag.
![image](https://github.com/compucorp/uk.co.compucorp.additionalsearchparams/assets/85277674/3e705580-ee76-4bbf-b26d-f294950e0c35)

## After
The contact search page works as expected.
![edddd](https://github.com/compucorp/uk.co.compucorp.additionalsearchparams/assets/85277674/1e3d9d00-4dda-4774-a190-b7d3e8da0329)

The search parameters are persisted on the result page.
<img width="1226" alt="Screenshot 2023-08-18 at 07 18 47" src="https://github.com/compucorp/uk.co.compucorp.additionalsearchparams/assets/85277674/70e2b39c-c507-4978-ba22-b6dab615ed7b">


## Technical Details
```php
$paramValue = CRM_Utils_Request::retrieve($paramName, $paramType);
```
This issue happens because the method didn't specify the method to retrieve value from, and since the tag can be in the POST body (as an array) or in the GET body (as a string), it results in an error.

The solution is to explicitly declare the GET Method body as where the value should be retrieved from.

We also resolve an issue where form default values are always replaced.
